### PR TITLE
Update all references to org

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!-- If this PR closes a GitHub issue, make sure the title starts with the issue number, and reference it here -->
-<!-- for example: Closes [#151](https://github.com/slacgismo/solar-data-tools/issues/151) <!--
+<!-- for example: Closes [#151](https://github.com/NREL/solar-data-tools/issues/151) <!--
 
 <!-- describe the changes comprising this PR here -->
 This PR addresses ...

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at bennetm@stanford.edu or smiskov@slac.stanford.edu.
+reported to the community leaders responsible for enforcement at bennetm@stanford.edu.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Contributions are welcome, and are greatly appreciated! Even small contributions
 
 ### Report Bugs
 
-To report a bug, first make sure there isn't already an open [GitHub Issue](https://github.com/slacgismo/solar-data-tools/issues)
+To report a bug, first make sure there isn't already an open [GitHub Issue](https://github.com/NREL/solar-data-tools/issues)
 about it. If not, you can submit a new issue, making sure to include:
 
 * Your OS name and version.
@@ -17,12 +17,12 @@ about it. If not, you can submit a new issue, making sure to include:
 
 ### Fix Open Issues
 
-Look through the [GitHub Issues](https://github.com/slacgismo/solar-data-tools/issues) for any
+Look through the [GitHub Issues](https://github.com/NREL/solar-data-tools/issues) for any
 reported bugs. Anything tagged with "bug" and "help wanted" is open to contributions.
 
 ### Implement Features
 
-Look through the [GitHub Issues](https://github.com/slacgismo/solar-data-tools/issues) for any
+Look through the [GitHub Issues](https://github.com/NREL/solar-data-tools/issues) for any
 feature requests. Anything tagged with "enhancement" and "help  wanted" is open to contributions.
 
 ### Write Documentation
@@ -36,7 +36,7 @@ Ready to contribute? Here's how to set up Solar Data Tools for local development
 
 1. You will need to have `git` installed on your local machine, and you will need some way to create and manage
 Python virtual environments. We recommend using `conda`.
-2. Create your own fork of the Solar Data Tools [repository](https://github.com/slacgismo/solar-data-tools).
+2. Create your own fork of the Solar Data Tools [repository](https://github.com/NREL/solar-data-tools).
 3. Clone your repository, for example by typing in your terminal:
 `git clone https://github.com/<your_username>/solar-data-tools.git`.
 4. Install `solardatatools` as editable in your new environment:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <br />
     <a href="https://solar-data-tools.readthedocs.io/"><strong>Explore our documentation </strong></a>
     ·
-    <a href="https://github.com/slacgismo/solar-data-tools/issues"><strong>Report Issue </strong></a>
+    <a href="https://github.com/NREL/solar-data-tools/issues"><strong>Report Issue </strong></a>
     <br />
     <br />
 </p>
@@ -69,7 +69,7 @@
 <tr>
   <td>License</td>
   <td>
-    <a href="https://github.com/slacgismo/solar-data-tools/blob/main/LICENSE">
+    <a href="https://github.com/NREL/solar-data-tools/blob/main/LICENSE">
         <img src="https://img.shields.io/pypi/l/solar-data-tools.svg" alt="license" />
     </a>
 </td>
@@ -80,11 +80,11 @@
     <a href="https://solar-data-tools.readthedocs.io/">
         <img src="https://readthedocs.org/projects/solar-data-tools/badge/?version=stable" alt="documentation build status" />
     </a>
-        <a href="https://github.com/slacgismo/solar-data-tools/actions/workflows/test.yml">
-        <img src="https://github.com/slacgismo/solar-data-tools/actions/workflows/test.yml/badge.svg?branch=main" alt="Actions build status" />
+        <a href="https://github.com/NREL/solar-data-tools/actions/workflows/test.yml">
+        <img src="https://github.com/NREL/solar-data-tools/actions/workflows/test.yml/badge.svg?branch=main" alt="Actions build status" />
     </a>
-    <a href="https://github.com/slacgismo/solar-data-tools/actions/workflows/build.yml">
-        <img src="https://github.com/slacgismo/solar-data-tools/actions/workflows/build.yml/badge.svg">
+    <a href="https://github.com/NREL/solar-data-tools/actions/workflows/build.yml">
+        <img src="https://github.com/NREL/solar-data-tools/actions/workflows/build.yml/badge.svg">
     </a>
   </td>
 </tr>
@@ -140,7 +140,7 @@ we did with the DOE's Solar Energy Technologies Office (SETO) with our colleague
   </img>
 </p>
 
-You can also check the [notebooks](https://github.com/slacgismo/solar-data-tools/blob/main/notebooks/examples) folder in this repo for more examples.
+You can also check the [notebooks](https://github.com/NREL/solar-data-tools/blob/main/notebooks/examples) folder in this repo for more examples.
 
 This work is supported by the U.S. Department of Energy’s Office of Energy Efficiency and Renewable Energy (EERE) under the Solar Energy Technologies Office Award Number 38529.
 
@@ -275,7 +275,7 @@ Solar Data Tools that you used. Solar Data Tools DOIs are listed at
 
 ## Versioning
 
-We use [Semantic Versioning](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/slacgismo/solar-data-tools/tags).
+We use [Semantic Versioning](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/NREL/solar-data-tools/tags).
 
 ## Authors
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -103,7 +103,7 @@ html_theme_options = {
     "navbar_align": "left",
     "navbar_end": ["theme-switcher", "navbar-icon-links"],
     "show_version_warning_banner": True,
-    "github_url": "https://github.com/slacgismo/solar-data-tools",
+    "github_url": "https://github.com/NREL/solar-data-tools",
     "show_toc_level": 1,
     "footer_start": ["copyright", "sphinx-version"],
     "navigation_with_keys": False,

--- a/docs/source/getting_started/contribute.rst
+++ b/docs/source/getting_started/contribute.rst
@@ -10,4 +10,4 @@ For code and documentation contributions, our :doc:`../../index_dev` will help y
 to submitting a pull request. We are still in the process of developing our guidelines, so if anything is unclear, or if you'd like more clarity on
 some parts of the documentation, please consider submitting a `GitHub Issue`_!
 
-.. _GitHub Issue: https://github.com/slacgismo/solar-data-tools/issues
+.. _GitHub Issue: https://github.com/NREL/solar-data-tools/issues

--- a/docs/source/project_details/citation.md
+++ b/docs/source/project_details/citation.md
@@ -12,7 +12,7 @@ If you use Solar Data Tools in your research, please cite:
   Nimish Telang, Nimish Yadav, Elpiniki Apostolaki-Iosifidou, Claire Berschauer, Chengcheng Ding,
   Jonathan Goncalves, Victor-Haoyang Lian, Tristan Lin, Alejandro Londono-Hurtado, Junlin Luo, Xiao Ming,
   David Jose Florez Rodriguez, Derin Serbetcioglu, Shixian Sheng, Jose St Louis, Tadatoshi Takahashi, and Haoxi Zhang. (2024).
-  slacgismo/solar-data-tools. Zenodo. doi: [10.5281/zenodo.5056959](https://zenodo.org/doi/10.5281/zenodo.5056959)
+  NREL/solar-data-tools. Zenodo. doi: [10.5281/zenodo.5056959](https://zenodo.org/doi/10.5281/zenodo.5056959)
 
 ## Citing technical details (_e.g._, SDT algorithms)
 

--- a/docs/source/project_details/license.rst
+++ b/docs/source/project_details/license.rst
@@ -6,5 +6,5 @@ This project is licensed under the BSD 2-Clause License - see the
 
 .. |PyPI release| image:: https://img.shields.io/pypi/v/solar-data-tools.svg
    :target: https://pypi.org/project/solar-data-tools/
-.. |Anaconda Cloud release| image:: https://anaconda.org/slacgismo/solar-data-tools/badges/version.svg
-   :target: https://anaconda.org/slacgismo/solar-data-tools
+.. |Anaconda Cloud release| image:: https://anaconda.org/conda-forge/solar-data-tools/badges/version.svg
+   :target: https://anaconda.org/conda-forge/solar-data-tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dask = [
     ]
 
 [project.urls]
-Homepage = "https://github.com/slacgismo/solar-data-tools"
+Homepage = "https://github.com/NREL/solar-data-tools"
 Documentation = "https://solar-data-tools.readthedocs.io/"
-"Bug Tracker" = "https://github.com/slacgismo/solar-data-tools/issues"
-Discussions = "https://github.com/slacgismo/solar-data-tools/discussions"
+"Bug Tracker" = "https://github.com/NREL/solar-data-tools/issues"
+Discussions = "https://github.com/NREL/solar-data-tools/discussions"


### PR DESCRIPTION
This is purely for consistency/cleanup, since GitHub will forever redirect references to the old org to the new one.
